### PR TITLE
Run weekly CI

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -19,7 +19,7 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    if: (github.repository == 'astropy/specutils' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
+    if: (github.repository == 'xuanxu/specutils' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR updates temporarily the repo name for the check in the Weekly CI workflow in order to run it and test it